### PR TITLE
Minor fixes + More Consistent Arguments for Argument Parser

### DIFF
--- a/torchcam/camera.py
+++ b/torchcam/camera.py
@@ -129,7 +129,7 @@ class DepthCamera:
 
                 # Keyboard input handling
                 key = cv2.waitKey(10)
-                if key == 32 and not self.estimator.live_render:
+                if key == 32 or key == ord("c") and not self.estimator.live_render:
                     self.capture(frame)  # Capture frame on spacebar press
                 if key == 27 or key == ord("q"):
                     print("Exiting program.")

--- a/torchcam/cli.py
+++ b/torchcam/cli.py
@@ -35,7 +35,7 @@ def get_configs() -> argparse.Namespace:
         description="Applying PyTorch MiDaS model on live webcam capture."
     )
     parser.add_argument(
-        "mode",
+        "--mode",
         type=str,
         help="Set to \'live\' for live depth-capture, or \'standard\' for single image capture."
     )


### PR DESCRIPTION
This is a really minor change and I'm not sure if the repo accepts pull requests:


I noticed that the "C" button wasn't capturing the depth map in "standard" mode (tested on my MacBook M1 on macOS Monterey 12.6.2) so I changed the `if key == 32 and not self.estimator.live_render:` to `if key == 32 or key == ord("c") and not self.estimator.live_render:` in `torchcam/camera.py`

I also noticed that there was a bit of inconsistency with the argument parser, since it was expecting simply `mode` when all other arguments had a `--` in front of them.